### PR TITLE
bug

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -93,7 +93,7 @@ class BootstrapForm(forms.Form):
             # If the field contains errors, render the errors to a <ul>
             # using the error_list helper function.
             # bf_errors = error_list([escape(error) for error in bf.errors])
-            bf_errors = bf.errors
+            bf_errors = ', '.join([e for e in bf.errors])
         else:
             bf_errors = ''
 

--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -99,7 +99,7 @@ class BootstrapForm(forms.Form):
 
         if bf.is_hidden:
             # If the field is hidden, add it at the top of the form
-            self.prefix.append(unicode(bf))
+#            self.prefix.append(unicode(bf))
 
             # If the hidden field has errors, append them to the top_errors
             # list which will be printed out at the top of form


### PR DESCRIPTION
hey,

the line I just commented prepends the string '[<input type=....' to the prefix so each field in the form comes out like <label for="id_u[<input .... 

and it screws up the whole form.  so I guess it's not doing what it's intended to do and I don't think moving the field to beginning of form is relevant at all so I just commented it out instead of trying to make it do the thing you wanted it to do.
