### PR TITLE
Fixed incorrect placement of css_class optional parameter

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -159,10 +159,10 @@ class BootstrapModelForm(forms.ModelForm, BootstrapMixin):
 class Fieldset(object):
     """ Fieldset container. Renders to a <fieldset>. """
 
-    def __init__(self, legend, css_class=None, *fields):
+    def __init__(self, legend, *fields, **kwargs):
         self.legend_html = legend and ('<legend>%s</legend>' % legend) or ''
         self.fields = fields
-        self.css_class = css_class
+        self.css_class = kwargs.get('css_class')
     
     def as_html(self, form):
         class_str = self.css_class and (' class="%s"' % self.css_class) or ''


### PR DESCRIPTION
Commit bc3e8e29d added support for an optional parameter, `css_class` to `Fieldset`. The syntax that was used is only valid in python 3, not python 2.
#36 attempted to fix this by moving the parameter to _before_ the `*fields` arguments, but this made it consume the second argument, which is not the intended behavior. This fixes it.

cc @mikery and @linked
