### PR TITLE
Added get_layout() function

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -14,13 +14,6 @@ class BootstrapMixin(object):
 
     def __init__(self, *args, **kwargs):
         super(BootstrapMixin, self).__init__(*args, **kwargs)
-        # do we have an explicit layout?
-        if hasattr(self, 'Meta') and hasattr(self.Meta, 'layout'):
-            self.layout = self.Meta.layout
-        else:
-            # Construct a simple layout using the keys from the fields
-            self.layout = self.fields.keys()
-
         if hasattr(self, 'Meta') and hasattr(self.Meta, 'custom_fields'):
             self.custom_fields = self.Meta.custom_fields
         else:
@@ -39,13 +32,23 @@ class BootstrapMixin(object):
         return ''.join(["<div class=\"alert alert-error\">%s</div>" % error
                         for error in self.top_errors])
 
+    def get_layout(self):
+        """ Return the user-specified layout if one is available, otherwise
+            build a default layout containing all fields.
+        """
+        if hasattr(self, 'Meta') and hasattr(self.Meta, 'layout'):
+            return self.Meta.layout
+        else:
+            # Construct a simple layout using the keys from the fields
+            return self.fields.keys()
+
     def as_div(self):
         """ Render the form as a set of <div>s. """
 
         self.top_errors = self.non_field_errors()
         self.prefix_fields = []
 
-        output = self.render_fields(self.layout)
+        output = self.render_fields(self.get_layout())
 
         if self.top_errors:
             errors = self.top_errors_as_html()


### PR DESCRIPTION
This makes dynamic layouts a bit easier when working with form inheritance. If get_layout is not overridden, the default behaviour is used (Meta.layout if it is given, otherwise fields.keys()).

A (not very good) example:

from bootstrap.forms import BootstrapForm, Fieldset

class LoginForm(BootstrapForm):
    username = forms.CharField(max_length=100)
    password = forms.CharField(widget=forms.PasswordInput(), max_length=100)

```
def get_layout(self):
    return Fieldset("Please Login", "username", "password", )
```
