### PR TITLE
i18n fixed for Fieldset legend.

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -158,11 +158,12 @@ class Fieldset(object):
     """ Fieldset container. Renders to a <fieldset>. """
 
     def __init__(self, legend, *fields, **kwargs):
-        self.legend_html = legend and ('<legend>%s</legend>' % legend) or ''
+        self.legend = legend
         self.fields = fields
         self.css_class = kwargs.get('css_class')
 
     def as_html(self, form):
+        legend_html = self.legend and (u'<legend>%s</legend>' % self.legend) or ''
         class_str = self.css_class and (' class="%s"' % self.css_class) or ''
-        return u'<fieldset%s>%s%s</fieldset>' %  (class_str, self.legend_html, form.render_fields(self.fields), )
+        return u'<fieldset%s>%s%s</fieldset>' %  (class_str, legend_html, form.render_fields(self.fields), )
 


### PR DESCRIPTION
Since ugettext_lazy is required we need to make sure the string is not resolved during the class initialization.
Also, a unicode object is required for ugettext_lazy to work.
