### PR TITLE
Make help_text behave like the examples in Bootstrap

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -113,7 +113,7 @@ class BootstrapMixin(object):
 
             if field_instance.help_text:
                 # The field has a help_text, construct <span> tag
-                help_text = '<span class="help_text">%s</span>' % force_unicode(field_instance.help_text)
+                help_text = '<span class="help-block">%s</span>' % force_unicode(field_instance.help_text)
             else:
                 help_text = u''
 

--- a/bootstrap/templates/bootstrap/field_default.html
+++ b/bootstrap/templates/bootstrap/field_default.html
@@ -6,7 +6,7 @@
         <span class="help-inline">{{ errors }}</span>
         {% endif %}
         {% if help_text %}
-        <p class="help-block">{{ help_text }}</p>
+        {{ help_text }}
         {% endif %}
     </div>
 </div> <!-- /clearfix -->


### PR DESCRIPTION
Use the correct class (help-block) for the help_text span, and remove the p element. Makes forms behave more consistently (especially in hero units).
