### PR TITLE
Configurable help styles for forms

### DIFF
--- a/bootstrap/forms.py
+++ b/bootstrap/forms.py
@@ -24,6 +24,11 @@ class BootstrapMixin(object):
         else:
             self.template_base = "bootstrap"
 
+        if hasattr(self, 'Meta') and hasattr(self.Meta, 'help_style'):
+            self.help_style = self.Meta.help_style
+        else:
+            self.help_style = "block"
+
     # For backward compatibility
     __bootstrap__ = __init__
 
@@ -113,7 +118,7 @@ class BootstrapMixin(object):
 
             if field_instance.help_text:
                 # The field has a help_text, construct <span> tag
-                help_text = '<span class="help-block">%s</span>' % force_unicode(field_instance.help_text)
+                help_text = '<span class="help-%s">%s</span>' % (self.help_style, force_unicode(field_instance.help_text))
             else:
                 help_text = u''
 

--- a/bootstrap/tests.py
+++ b/bootstrap/tests.py
@@ -19,6 +19,17 @@ class LoginForm(BootstrapForm):
     password = forms.CharField(widget=forms.PasswordInput(), max_length=100)
 
 
+class InlineHelpForm(BootstrapForm):
+    class Meta:
+        help_style = "inline"
+        layout = (
+            Fieldset("Please Login", "username", "password", ),
+        )
+
+    username = forms.CharField(max_length=100, help_text="A username")
+    password = forms.CharField(widget=forms.PasswordInput(), max_length=100)
+
+
 class FormTests(TestCase):
     def test_form_fieldsets(self):
         """
@@ -42,4 +53,30 @@ class FormTests(TestCase):
 </div> <!-- /clearfix -->
 </fieldset>"""
         form = LoginForm()
+        self.assertEqual(str(form), expected)
+
+    def test_help_inline(self):
+        """
+        Tests that inline help spans are rendered properly.
+        """
+        expected = """<fieldset class="please_login"><legend>Please Login</legend><div id="div_id_username" class="control-group">
+    <label class="control-label" for="id_username">Username</label>
+    <div class="controls">
+        <input id="id_username" type="text" name="username" maxlength="100" />
+        
+        
+        <span class="help-inline">A username</span>
+        
+    </div>
+</div> <!-- /clearfix -->
+<div id="div_id_password" class="control-group">
+    <label class="control-label" for="id_password">Password</label>
+    <div class="controls">
+        <input id="id_password" type="password" name="password" maxlength="100" />
+        
+        
+    </div>
+</div> <!-- /clearfix -->
+</fieldset>"""
+        form = InlineHelpForm()
         self.assertEqual(str(form), expected)


### PR DESCRIPTION
Would be nice if it could be done per-field but couldn't see an easy way to do that.
